### PR TITLE
Default viewport 1440x900 + browser_resize tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ claude mcp add kite --transport http http://localhost:8090/mcp
 | `BROWSER_EXECUTABLE` | auto-detect | Path to chrome / chromium / chrome-headless-shell. When unset: a system Chrome/Chromium is detected, else a `kite install`-managed build in the cache dir |
 | `BROWSER_NO_SANDBOX` | unset | Set (any value) to pass `--no-sandbox` (containers) |
 | `KITE_HEADLESS` | unset | Kite launches a **headed** (visible) browser by default so you can watch automation. Set (any value) to run **headless** — required on servers, CI, and containers with no display, where a headed Chrome fails to launch |
+| `KITE_VIEWPORT` | `1440x900` | Default viewport / window size as `WIDTHxHEIGHT` (Chromium's own default is a cramped 800x600). Adjust at runtime with the `browser_resize` tool |
 | `MCP_CONTEXT_POOL` | `2` | Number of pre-warmed blank browser contexts kept ready so a **new** session gets an instantly-usable context+page (zero context-creation latency). `0` disables. The pool refills in the background and drains with the browser on idle-reap (it never keeps the process alive) |
 | `KITE_CACHE_DIR` | `<tmp>/kitewright-cache` | Shared on-disk HTTP cache (`--disk-cache-dir`), stable across launches so repeat asset fetches hit cache. NOTE: per-session isolated contexts (cookie isolation) use an ephemeral cache; this benefits the browser's default context |
 | `KITE_PREWARM_URL` | unset | If set, prewarm navigates a throwaway page to this origin to establish DNS+TLS+connection before the first real navigate. No-op when unset |

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -35,6 +35,7 @@ use chromiumoxide::cdp::browser_protocol::target::{
 use chromiumoxide::cdp::js_protocol::runtime::{
     EnableParams as RuntimeEnableParams, EventConsoleApiCalled, RemoteObject,
 };
+use chromiumoxide::handler::viewport::Viewport;
 use chromiumoxide::page::{Page, ScreenshotParams};
 use futures::StreamExt;
 use tokio::sync::Mutex;
@@ -96,6 +97,11 @@ pub struct EngineConfig {
     /// connection is established before the first real navigate. Read from
     /// `KITE_PREWARM_URL`. No-op when unset.
     pub prewarm_url: Option<String>,
+    /// Default viewport (and, when headed, window) size in CSS pixels. Chromium's
+    /// own default is a cramped 800x600; this defaults to 1440x900. Read from
+    /// `KITE_VIEWPORT` as `WIDTHxHEIGHT` (e.g. `1280x720`). Adjustable at runtime
+    /// via the `browser_resize` tool.
+    pub viewport: (u32, u32),
 }
 
 impl Default for EngineConfig {
@@ -133,8 +139,21 @@ impl Default for EngineConfig {
             prewarm_url: std::env::var("KITE_PREWARM_URL")
                 .ok()
                 .filter(|s| !s.is_empty()),
+            viewport: std::env::var("KITE_VIEWPORT")
+                .ok()
+                .and_then(|s| parse_viewport(&s))
+                .unwrap_or((1440, 900)),
         }
     }
+}
+
+/// Parse a `WIDTHxHEIGHT` viewport string (e.g. `1280x720`). Returns None on any
+/// malformed input so the caller falls back to the default.
+fn parse_viewport(s: &str) -> Option<(u32, u32)> {
+    let (w, h) = s.split_once(['x', 'X'])?;
+    let w: u32 = w.trim().parse().ok().filter(|n| *n > 0)?;
+    let h: u32 = h.trim().parse().ok().filter(|n| *n > 0)?;
+    Some((w, h))
 }
 
 // -- browser install cache (shared with `kite install`) -----------------------
@@ -626,9 +645,20 @@ impl Engine {
         if self.config.no_sandbox {
             args.push("no-sandbox".to_string());
         }
+        // Size the OS window (headed) to match the viewport instead of Chrome's
+        // cramped default.
+        let (vw, vh) = self.config.viewport;
+        args.push(format!("window-size={vw},{vh}"));
         builder = builder.args(args);
-        // Headed (visible window) mode is opt-in via KITE_HEADFUL; the default
-        // is headless (correct for agents/servers/CI).
+        // Replace chromiumoxide's 800x600 default viewport with our default (or
+        // KITE_VIEWPORT) so pages render — and screenshot — at a usable size.
+        builder = builder.viewport(Viewport {
+            width: vw,
+            height: vh,
+            ..Viewport::default()
+        });
+        // Headed launches a visible window; headless (KITE_HEADLESS) is correct
+        // for agents/servers/CI.
         if self.config.headful {
             builder = builder.with_head();
         }
@@ -1031,6 +1061,36 @@ impl BrowserSession {
             .and_then(|r| r.get("value"))
             .cloned()
             .unwrap_or(serde_json::Value::Null))
+    }
+
+    /// Resize the page's viewport to `width`x`height` CSS pixels via CDP
+    /// `Emulation.setDeviceMetricsOverride` (affects layout and screenshots). A
+    /// zero width AND height clears the override, restoring the launch default.
+    pub async fn resize(&self, width: u32, height: u32) -> Result<()> {
+        let mut st = self.shared.state.lock().await;
+        let page = self.ensure_page(&mut st, false).await?;
+        let (id, params) = if width == 0 && height == 0 {
+            (
+                "Emulation.clearDeviceMetricsOverride",
+                serde_json::json!({}),
+            )
+        } else if width == 0 || height == 0 {
+            bail!("resize needs a non-zero width and height (or 0x0 to reset)");
+        } else {
+            (
+                "Emulation.setDeviceMetricsOverride",
+                serde_json::json!({
+                    "width": width,
+                    "height": height,
+                    "deviceScaleFactor": 1,
+                    "mobile": false,
+                }),
+            )
+        };
+        page.execute(RawCommand { id, params })
+            .await
+            .with_context(|| format!("{id} failed"))?;
+        Ok(())
     }
 
     /// Convert the current page's main content to Markdown for LLM consumption

--- a/crates/engine/tests/engine_test.rs
+++ b/crates/engine/tests/engine_test.rs
@@ -245,6 +245,7 @@ fn test_engine_cfg(idle_ttl: Duration, context_pool_size: usize) -> Engine {
         context_pool_size,
         cache_dir: std::env::temp_dir().join(unique),
         prewarm_url: None,
+        viewport: (1440, 900),
     })
 }
 
@@ -1269,6 +1270,7 @@ async fn connection_prewarm_noops_when_unset_and_warms_when_set() {
         context_pool_size: 1,
         cache_dir: std::env::temp_dir().join(format!("kitewright-test-pw-{}", std::process::id())),
         prewarm_url: Some(target.clone()),
+        viewport: (1440, 900),
     });
     engine2
         .prewarm()
@@ -1307,6 +1309,7 @@ async fn shared_cache_dir_is_created_and_reused() {
         context_pool_size: 1,
         cache_dir: cache_dir.clone(),
         prewarm_url: None,
+        viewport: (1440, 900),
     });
     let url = start_fixture_server().await;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -152,6 +152,15 @@ struct EvaluateParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ResizeParams {
+    /// Viewport width in CSS pixels. Use 0 (with height 0) to reset to the
+    /// launch default.
+    width: u32,
+    /// Viewport height in CSS pixels.
+    height: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct HandleDialogParams {
     /// Accept (true) or dismiss (false) the next dialog(s)
     accept: bool,
@@ -609,6 +618,19 @@ impl BrowserMcp {
     ) -> Result<CallToolResult, McpError> {
         let value = self.session.evaluate(&script).await.map_err(err)?;
         Ok(json_text(serde_json::json!({ "result": value })))
+    }
+
+    #[tool(
+        description = "Resize the page viewport (CSS pixels), affecting layout and screenshots — e.g. 1440x900 desktop or 390x844 mobile. Pass width:0 and height:0 to reset to the launch default. The launch default is 1440x900 (override with KITE_VIEWPORT)."
+    )]
+    async fn browser_resize(
+        &self,
+        Parameters(ResizeParams { width, height }): Parameters<ResizeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.session.resize(width, height).await.map_err(err)?;
+        Ok(json_text(
+            serde_json::json!({ "width": width, "height": height }),
+        ))
     }
 
     #[tool(


### PR DESCRIPTION
Chromium's 800x600 default made the headed window/screenshots tiny. Launch at 1440x900 (configurable via KITE_VIEWPORT), and add a browser_resize tool (setDeviceMetricsOverride; 0x0 resets). Verified: default 1440x900, resize->390x844, reset clears the override.