### PR TITLE
Session survives idle reap (auto-restore) + browser_fill_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ claude mcp add kite --transport http http://localhost:8090/mcp
 | `BROWSER_EXECUTABLE` | auto-detect | Path to chrome / chromium / chrome-headless-shell. When unset: a system Chrome/Chromium is detected, else a `kite install`-managed build in the cache dir |
 | `BROWSER_NO_SANDBOX` | unset | Set (any value) to pass `--no-sandbox` (containers) |
 | `KITE_HEADLESS` | unset | Kite launches a **headed** (visible) browser by default so you can watch automation. Set (any value) to run **headless** — required on servers, CI, and containers with no display, where a headed Chrome fails to launch |
+| `KITE_IDLE_TIMEOUT_SECS` | `1800` | Idle seconds before a headless browser is reaped to free memory. Default 30min keeps a session alive across normal pauses (headed never reaps). A reap that does happen is recovered by cookie **auto-restore**, so an authenticated session survives it. Lower it on a memory-constrained multi-session server |
+| `KITE_ALLOW_SECRET_FILES` | unset | Set (any value) to let `browser_fill_secret` read `file:/path` secrets from disk. Optionally fence reads to a directory with `KITE_SECRET_DIR`. `env:` secrets need no opt-in |
 | `KITE_VIEWPORT` | `1440x900` | Default viewport / window size as `WIDTHxHEIGHT` (Chromium's own default is a cramped 800x600). Adjust at runtime with the `browser_resize` tool |
 | `MCP_CONTEXT_POOL` | `2` | Number of pre-warmed blank browser contexts kept ready so a **new** session gets an instantly-usable context+page (zero context-creation latency). `0` disables. The pool refills in the background and drains with the browser on idle-reap (it never keeps the process alive) |
 | `KITE_CACHE_DIR` | `<tmp>/kitewright-cache` | Shared on-disk HTTP cache (`--disk-cache-dir`), stable across launches so repeat asset fetches hit cache. NOTE: per-session isolated contexts (cookie isolation) use an ephemeral cache; this benefits the browser's default context |
@@ -157,6 +159,7 @@ All tools operate on the session's persistent page.
 - `browser_click {selector, timeout_ms?}` — scroll into view + click the first match
 - `browser_type {selector, text, clear?, press_enter?, timeout_ms?}` — focus and type into an element
 - `browser_fill_form {fields: [{selector, value}], timeout_ms?}` — fill several inputs in one call (per-field ok/error summary)
+- `browser_fill_secret {selector, secret_ref, press_enter?, timeout_ms?}` — type a secret (password) whose plaintext **never enters the tool call**: `secret_ref` is `env:NAME` (a server env var) or `file:/path` (opt-in via `KITE_ALLOW_SECRET_FILES`). Resolved server-side, then typed
 - `browser_select_option {selector, value?, label?, timeout_ms?}` — pick an `<option>` by value or visible label (fires `change`)
 - `browser_hover {selector, timeout_ms?}` — move the mouse to an element's center (reveals CSS `:hover` menus)
 - `browser_press_key {key}` — send Enter / Tab / Escape / ArrowDown / … to the focused element

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chromiumoxide::browser::{Browser, BrowserConfig};
 use chromiumoxide::cdp::browser_protocol::accessibility as ax;
 use chromiumoxide::cdp::browser_protocol::browser::BrowserContextId;
@@ -109,15 +109,17 @@ impl Default for EngineConfig {
         // Headed by default; KITE_HEADLESS opts into headless.
         let headful = std::env::var("KITE_HEADLESS").is_err();
         Self {
-            // Headless (server) reaps aggressively to free ~300MB. Headed is
-            // driven by a human at human pace — with pauses to read, type
-            // credentials, or coordinate — so a 120s reap would kill the window
-            // mid-task; give it a much longer idle window.
-            idle_ttl: if headful {
-                Duration::from_secs(1800)
-            } else {
-                Duration::from_secs(120)
-            },
+            // Keep the browser alive across normal between-turn pauses (an agent
+            // reading, coordinating, or a human typing credentials) so a session
+            // isn't dropped mid-flow — the #1 gap vs Playwright, which never reaps
+            // mid-session. Default 30min idle window (headed never reaps at all);
+            // tune with KITE_IDLE_TIMEOUT_SECS on a memory-constrained server. A
+            // reap that does happen is recovered by the cookie auto-restore.
+            idle_ttl: std::env::var("KITE_IDLE_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or(Duration::from_secs(1800)),
             nav_timeout: Duration::from_secs(20),
             no_sandbox: std::env::var("BROWSER_NO_SANDBOX").is_ok(),
             headful,
@@ -820,6 +822,11 @@ struct SessionState {
     /// Applied automatically after the next navigation to that origin, since
     /// localStorage can only be written while on the matching origin.
     pending_localstorage: Option<(String, HashMap<String, String>)>,
+    /// Storage state (cookies + localStorage + url) auto-captured after each
+    /// navigation, replayed onto the fresh browser context when the browser is
+    /// reaped or crashes so an authenticated session survives a relaunch. Never
+    /// cleared on relaunch — only overwritten by the next successful capture.
+    auto_state: Option<String>,
     /// Previous snapshot text, used by [`BrowserSession::snapshot_diff`] to emit
     /// only what changed since the last snapshot in this session.
     last_snapshot: Option<String>,
@@ -1265,6 +1272,23 @@ impl BrowserSession {
         .await
     }
 
+    /// Type a SECRET into `selector` without the plaintext ever appearing in the
+    /// tool call. `secret_ref` is a reference resolved server-side:
+    /// `env:NAME` (from the server's environment) or `file:/path` (from disk,
+    /// opt-in via `KITE_ALLOW_SECRET_FILES`, optionally fenced to
+    /// `KITE_SECRET_DIR`). Clears the field first, then types the resolved value.
+    pub async fn fill_secret(
+        &self,
+        selector: &str,
+        secret_ref: &str,
+        press_enter: bool,
+        timeout_ms: Option<u64>,
+    ) -> Result<()> {
+        let value = resolve_secret_ref(secret_ref)?;
+        self.type_text(selector, &value, true, press_enter, timeout_ms)
+            .await
+    }
+
     /// Fill several inputs in one call. Each field is typed with `clear=true`
     /// (replace existing value). Never aborts on the first failure: returns a
     /// per-field outcome so an agent sees exactly which fields succeeded.
@@ -1648,14 +1672,15 @@ impl BrowserSession {
         // First use, or the page belongs to a dead browser launch.
         let lost_state = st.page.take().is_some();
         st.context_id = None;
+        // Snapshot the auto-restore state to replay after the fresh page is
+        // built. Never clear auto_state itself here — it's the only copy.
+        let recover_state = if lost_state {
+            st.auto_state.clone()
+        } else {
+            None
+        };
         if lost_state {
             st.last_url = None;
-            if !navigating {
-                bail!(
-                    "the browser was restarted (idle reap or crash) and this session's \
-                     page state was lost — call browser_navigate to start again"
-                );
-            }
         }
         // Prefer a pre-warmed context from the pool (zero context-creation
         // latency); the pool holds FRESH, unused contexts, so cookie isolation
@@ -1698,10 +1723,40 @@ impl BrowserSession {
         // the page + the session's std-Mutex buffers, no async locks).
         drop(guard);
         self.arm_capture(&page).await;
+        // Replay captured cookies + localStorage onto the fresh context so the
+        // recreated session is still authenticated after a reap/crash.
+        let recovered = match &recover_state {
+            Some(state) => match apply_saved_state(&page, st, state).await {
+                Ok(()) => {
+                    tracing::info!("auto-restore: replayed session cookies after relaunch");
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!("auto-restore: replay failed: {e:#}");
+                    false
+                }
+            },
+            None => false,
+        };
         // Lazily top the pool back up in the background (never blocks this call
         // and never keeps the browser alive).
         engine.spawn_pool_refill();
         tracing::debug!(relaunched = lost_state, "session page created");
+        // A non-navigating op can't run on the blank recreated page; ask the
+        // caller to navigate. Cookies are already restored, so the reload stays
+        // authenticated (auth survives the reap/crash).
+        if lost_state && !navigating {
+            if recovered {
+                bail!(
+                    "the browser was restarted (idle reap or crash); this session's cookies \
+                     were preserved — call browser_navigate to reload (you'll still be signed in)"
+                );
+            }
+            bail!(
+                "the browser was restarted (idle reap or crash) and this session's page state \
+                 was lost — call browser_navigate to start again"
+            );
+        }
         Ok(page)
     }
 
@@ -1815,6 +1870,13 @@ impl BrowserSession {
                 .unwrap_or_else(|| url.to_string()),
         );
         apply_pending_localstorage(st, page).await;
+        // Snapshot cookies + localStorage so an authenticated session survives a
+        // reap/crash (see ensure_page's relaunch branch). Log — don't swallow —
+        // a capture failure so it's diagnosable rather than a silent no-restore.
+        match capture_state(page).await {
+            Ok(state) => st.auto_state = Some(state),
+            Err(e) => tracing::warn!("auto-restore: failed to capture session state: {e:#}"),
+        }
         Ok(())
     }
 }
@@ -1919,6 +1981,42 @@ fn resolve_actionable_timeout(timeout_ms: Option<u64>) -> Duration {
     match timeout_ms {
         Some(ms) => Duration::from_millis(ms.min(WAIT_FOR_MAX_TIMEOUT_MS)),
         None => actionable_timeout(),
+    }
+}
+
+/// Resolve a secret reference to its plaintext, server-side, so the value never
+/// travels in the MCP tool call. `env:NAME` reads `NAME` from the server's
+/// environment. `file:PATH` reads `PATH` from disk — opt-in via
+/// `KITE_ALLOW_SECRET_FILES=1`, and if `KITE_SECRET_DIR` is set the canonicalized
+/// path must live under it (mirroring the `KITE_ALLOW_FILE_URLS` anti-exfiltration
+/// guard); a trailing newline is trimmed. A bare value with no scheme is rejected
+/// — passing plaintext would defeat the purpose of the tool.
+fn resolve_secret_ref(reference: &str) -> Result<String> {
+    if let Some(name) = reference.strip_prefix("env:") {
+        std::env::var(name).map_err(|_| anyhow!("secret env var {name:?} is not set on the server"))
+    } else if let Some(path) = reference.strip_prefix("file:") {
+        if std::env::var("KITE_ALLOW_SECRET_FILES").is_err() {
+            bail!(
+                "file: secrets are disabled by default; set KITE_ALLOW_SECRET_FILES=1 to allow \
+                 reading secret values from local files"
+            );
+        }
+        let canon = std::path::Path::new(path)
+            .canonicalize()
+            .map_err(|e| anyhow!("secret file {path:?}: {e}"))?;
+        if let Ok(dir) = std::env::var("KITE_SECRET_DIR") {
+            let allowed = std::path::Path::new(&dir)
+                .canonicalize()
+                .context("KITE_SECRET_DIR does not exist")?;
+            if !canon.starts_with(&allowed) {
+                bail!("secret file {path:?} is outside KITE_SECRET_DIR");
+            }
+        }
+        let content = std::fs::read_to_string(&canon)
+            .map_err(|e| anyhow!("read secret file {path:?}: {e}"))?;
+        Ok(content.trim_end_matches(['\n', '\r']).to_string())
+    } else {
+        bail!("secret must be referenced as env:NAME or file:PATH (never pass the plaintext value)")
     }
 }
 

--- a/crates/engine/tests/engine_test.rs
+++ b/crates/engine/tests/engine_test.rs
@@ -668,6 +668,97 @@ async fn save_and_restore_state_across_sessions() {
     engine.shutdown().await;
 }
 
+/// An authenticated session must survive an idle reap: cookies captured after
+/// navigation are auto-restored onto the relaunched browser, so the agent stays
+/// logged in across a pause that reaps the browser. This is the #1 gap vs
+/// Playwright (which keeps the browser alive) — verified end-to-end here.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_survives_idle_reap_via_auto_restore() {
+    if chrome_path().is_none() {
+        eprintln!("SKIP: no Chromium found (set BROWSER_EXECUTABLE)");
+        return;
+    }
+    let url = start_fixture_server().await;
+    // idle_ttl = 2s so the reaper kills the idle browser during our sleep below.
+    let engine = test_engine(Duration::from_secs(2));
+    let session = engine.create_session();
+
+    // Establish an authenticated session: set a cookie + localStorage, then
+    // re-navigate so the post-navigation auto-capture snapshots the cookie.
+    session.navigate(&url).await.expect("navigate failed");
+    session
+        .click("#set-state-btn", None)
+        .await
+        .expect("set state failed");
+    session
+        .wait_for(None, Some("state-set"), Some(2_000))
+        .await
+        .expect("state was not set");
+    session
+        .navigate(&url)
+        .await
+        .expect("re-navigate (to capture cookie) failed");
+
+    // Let the idle reaper kill the browser (ttl 2s, reaper period 2s).
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // The next navigation relaunches the browser; auto-restore must replay the
+    // cookie so we are still authenticated.
+    session
+        .navigate(&url)
+        .await
+        .expect("navigate after reap failed");
+    session
+        .click("#read-state-btn", None)
+        .await
+        .expect("read state failed");
+    let cookie = session.extract(None, "#cookie-out", None).await.unwrap();
+    assert!(
+        cookie
+            .first()
+            .map(|c| c.contains("sess-A-value"))
+            .unwrap_or(false),
+        "auth cookie did NOT survive the idle reap (auto-restore failed): {cookie:?}"
+    );
+
+    session.close().await;
+    engine.shutdown().await;
+}
+
+/// browser_fill_secret must resolve an `env:` reference server-side and type the
+/// resolved value into the field — the plaintext only ever lives in the server,
+/// never in the tool call. A bare (schemeless) reference is rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn fill_secret_resolves_env_and_types_it() {
+    if chrome_path().is_none() {
+        eprintln!("SKIP: no Chromium found (set BROWSER_EXECUTABLE)");
+        return;
+    }
+    std::env::set_var("KW_FILL_SECRET_TEST", "hunter2-secret");
+    let engine = test_engine(Duration::from_secs(60));
+    let s = engine.create_session();
+    s.set_content("<input id=pw>", None)
+        .await
+        .expect("set_content failed");
+    s.fill_secret("#pw", "env:KW_FILL_SECRET_TEST", false, None)
+        .await
+        .expect("fill_secret failed");
+    let value = s
+        .evaluate("document.getElementById('pw').value")
+        .await
+        .expect("evaluate failed");
+    assert_eq!(value, serde_json::json!("hunter2-secret"), "secret not typed");
+    // A schemeless (plaintext) reference is refused.
+    assert!(
+        s.fill_secret("#pw", "not-a-reference", false, None)
+            .await
+            .is_err(),
+        "plaintext secret ref should be rejected"
+    );
+    s.close().await;
+    engine.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn pdf_returns_valid_pdf_bytes() {
     if chrome_path().is_none() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -92,6 +92,20 @@ struct TypeParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct FillSecretParams {
+    /// CSS selector of the input to type the secret into
+    selector: String,
+    /// Secret REFERENCE resolved server-side — `env:NAME` or `file:/path`. Never
+    /// the plaintext value (that's the whole point: it stays out of the transcript).
+    secret_ref: String,
+    /// Press Enter after typing (submit forms)
+    #[serde(default)]
+    press_enter: bool,
+    /// Actionability timeout in milliseconds (default 5000, max 30000)
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct PressKeyParams {
     /// DOM key value, e.g. Enter, Tab, Escape, Backspace, ArrowDown, PageDown
     key: String,
@@ -507,6 +521,28 @@ impl BrowserMcp {
             .map_err(err)?;
         Ok(json_text(serde_json::json!({
             "typed": text, "selector": selector, "pressed_enter": press_enter
+        })))
+    }
+
+    #[tool(
+        description = "Type a SECRET (e.g. a password) into an input WITHOUT the plaintext appearing in the tool call/transcript. Pass `secret_ref` as `env:NAME` (a server environment variable) or `file:/path` (a local file, opt-in via KITE_ALLOW_SECRET_FILES). kitewright resolves it server-side and types it, clearing the field first."
+    )]
+    async fn browser_fill_secret(
+        &self,
+        Parameters(FillSecretParams {
+            selector,
+            secret_ref,
+            press_enter,
+            timeout_ms,
+        }): Parameters<FillSecretParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.session
+            .fill_secret(&selector, &secret_ref, press_enter, timeout_ms)
+            .await
+            .map_err(err)?;
+        // Echo the reference, never the resolved value.
+        Ok(json_text(serde_json::json!({
+            "filled_secret": true, "selector": selector, "secret_ref": secret_ref, "pressed_enter": press_enter
         })))
     }
 


### PR DESCRIPTION
Closes the top two gaps vs Playwright MCP. **#1 session stability:** keep-alive idle default (KITE_IDLE_TIMEOUT_SECS) + cookie auto-restore on reap/crash — verified by a deterministic reap test with a negative control proving it's real. **#2 secret injection:** browser_fill_secret resolves env:/file: server-side so passwords never hit the transcript. 22 engine tests pass, blocking sim green, clippy/fmt clean.