### PR TITLE
npx installer: kitewright-mcp launcher (like @playwright/mcp)

### DIFF
--- a/.github/workflows/mcp-npm.yml
+++ b/.github/workflows/mcp-npm.yml
@@ -1,0 +1,77 @@
+name: publish kitewright-mcp (npx)
+
+# Builds the `kite` binary for each platform, packs it into the matching
+# @kitewright/mcp-<target> package, then publishes those plus the `kitewright-mcp`
+# launcher so `npx kitewright-mcp` works everywhere.
+#
+# Requires repo secret NPM_TOKEN (npm automation token with publish rights to the
+# `kitewright-mcp` package and the `@kitewright` scope). Trigger by pushing a
+# `mcp-v*` tag or via workflow_dispatch. NOTE: not yet run end-to-end — the first
+# real run needs the npm scope/token provisioned.
+
+on:
+  push:
+    tags: ["mcp-v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            pkg: darwin-arm64
+            exe: kite
+          - runner: macos-13
+            target: x86_64-apple-darwin
+            pkg: darwin-x64
+            exe: kite
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            pkg: linux-x64-gnu
+            exe: kite
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            pkg: win32-x64-msvc
+            exe: kite.exe
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build kite (release)
+        run: cargo build --release -p kitewright --bin kite --target ${{ matrix.target }}
+      - name: Stage binary into the platform package
+        shell: bash
+        run: |
+          cp "target/${{ matrix.target }}/release/${{ matrix.exe }}" \
+             "npm/kitewright-mcp/npm/${{ matrix.pkg }}/${{ matrix.exe }}"
+      - name: Publish @kitewright/mcp-${{ matrix.pkg }}
+        working-directory: npm/kitewright-mcp/npm/${{ matrix.pkg }}
+        shell: bash
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-launcher:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Publish kitewright-mcp launcher
+        working-directory: npm/kitewright-mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ Each MCP session owns one persistent page inside its own Chromium browser contex
 
 ## Install
 
-Kitewright is a single static binary named `kite`. Pick whichever is easiest:
+The zero-install way — run it straight from **npx**, like `@playwright/mcp`:
+
+```bash
+claude mcp add kitewright -- npx -y kitewright-mcp
+```
+
+`npx kitewright-mcp` resolves the prebuilt `kite` binary for your platform (an
+optional per-platform dependency, esbuild-style) and starts a stdio MCP server —
+no Rust toolchain, no build. See [`npm/kitewright-mcp`](npm/kitewright-mcp).
+
+Or install the `kite` binary directly. Pick whichever is easiest:
 
 ```bash
 # Prebuilt binary (fastest) — downloads the GitHub Release asset for your platform:

--- a/npm/kitewright-mcp/.gitignore
+++ b/npm/kitewright-mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+npm/*/kite
+npm/*/kite.exe
+*.tgz

--- a/npm/kitewright-mcp/README.md
+++ b/npm/kitewright-mcp/README.md
@@ -1,0 +1,47 @@
+# kitewright-mcp
+
+Run the [kitewright](https://github.com/kitewright/kitewright) browser-automation
+MCP server with **npx** — no build step, no cargo. A tiny launcher that resolves
+the prebuilt `kite` binary for your platform and starts it over stdio.
+
+## Use it
+
+**Claude Code**
+
+```bash
+claude mcp add kitewright -- npx -y kitewright-mcp
+```
+
+**Cursor / any MCP client** (`mcp.json`)
+
+```jsonc
+{
+  "mcpServers": {
+    "kitewright": {
+      "command": "npx",
+      "args": ["-y", "kitewright-mcp"]
+    }
+  }
+}
+```
+
+That's it — `npx kitewright-mcp` with no args starts a stdio MCP server. Pass
+flags through for other modes (e.g. `npx kitewright-mcp --http` for the HTTP
+transport).
+
+## How it works
+
+The prebuilt `kite` binary ships as an optional per-platform dependency
+(`@kitewright/mcp-darwin-arm64`, `-darwin-x64`, `-linux-x64-gnu`,
+`-win32-x64-msvc`) — npm installs only the one matching your OS/arch, the same
+pattern esbuild and napi use. The launcher `require.resolve`s it and execs it.
+
+- Override the binary with `KITE_BINARY=/path/to/kite` (local dev / custom build).
+- If no prebuilt package covers your platform, install from source:
+  `cargo install --git https://github.com/kitewright/kitewright kitewright`.
+
+## Config
+
+All kitewright env vars apply (`KITE_HEADLESS`, `KITE_IDLE_TIMEOUT_SECS`,
+`KITE_ALLOW_SECRET_FILES`, …) — see the main
+[README](https://github.com/kitewright/kitewright#readme).

--- a/npm/kitewright-mcp/bin.js
+++ b/npm/kitewright-mcp/bin.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+"use strict";
+// Launcher for the kitewright MCP server. Resolves the prebuilt `kite` binary
+// for this platform (shipped as an optional per-platform dependency, the same
+// pattern esbuild/napi use) and execs it, passing through all args. With no
+// args it defaults to `--stdio` so `npx kitewright-mcp` starts a stdio MCP
+// server — the form MCP clients (Claude Code, Cursor) launch.
+const { spawnSync } = require("node:child_process");
+
+// platform-arch -> optional dependency package that ships the binary
+const PKG_BY_TARGET = {
+  "darwin-arm64": "@kitewright/mcp-darwin-arm64",
+  "darwin-x64": "@kitewright/mcp-darwin-x64",
+  "linux-x64": "@kitewright/mcp-linux-x64-gnu",
+  "win32-x64": "@kitewright/mcp-win32-x64-msvc",
+};
+
+function resolveBinary() {
+  // Explicit override wins (local dev / custom builds).
+  if (process.env.KITE_BINARY) return process.env.KITE_BINARY;
+
+  const target = `${process.platform}-${process.arch}`;
+  const exe = process.platform === "win32" ? "kite.exe" : "kite";
+  const pkg = PKG_BY_TARGET[target];
+  if (pkg) {
+    try {
+      return require.resolve(`${pkg}/${exe}`);
+    } catch {
+      /* optional dep not installed for this platform — fall through */
+    }
+  }
+  // Last resort: a `kite` already on PATH (e.g. `cargo install`).
+  return exe;
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0) args.push("--stdio");
+
+const bin = resolveBinary();
+const res = spawnSync(bin, args, { stdio: "inherit" });
+
+if (res.error) {
+  const target = `${process.platform}-${process.arch}`;
+  process.stderr.write(
+    `kitewright-mcp: could not launch the kite binary (${bin}): ${res.error.message}\n` +
+      (PKG_BY_TARGET[target]
+        ? `The prebuilt package for ${target} may have failed to install. `
+        : `No prebuilt binary is published for ${target}. `) +
+      `Set KITE_BINARY=/path/to/kite, or install it with \`cargo install --git https://github.com/kitewright/kitewright kitewright\`.\n`,
+  );
+  process.exit(1);
+}
+process.exit(res.status == null ? 1 : res.status);

--- a/npm/kitewright-mcp/npm/darwin-arm64/package.json
+++ b/npm/kitewright-mcp/npm/darwin-arm64/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@kitewright/mcp-darwin-arm64",
+  "version": "0.1.0",
+  "description": "Prebuilt kite binary for kitewright-mcp on macOS arm64.",
+  "license": "MIT",
+  "repository": "github:kitewright/kitewright",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["kite"]
+}

--- a/npm/kitewright-mcp/npm/darwin-x64/package.json
+++ b/npm/kitewright-mcp/npm/darwin-x64/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@kitewright/mcp-darwin-x64",
+  "version": "0.1.0",
+  "description": "Prebuilt kite binary for kitewright-mcp on macOS x64.",
+  "license": "MIT",
+  "repository": "github:kitewright/kitewright",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["kite"]
+}

--- a/npm/kitewright-mcp/npm/linux-x64-gnu/package.json
+++ b/npm/kitewright-mcp/npm/linux-x64-gnu/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@kitewright/mcp-linux-x64-gnu",
+  "version": "0.1.0",
+  "description": "Prebuilt kite binary for kitewright-mcp on Linux x64 (glibc).",
+  "license": "MIT",
+  "repository": "github:kitewright/kitewright",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "libc": ["glibc"],
+  "files": ["kite"]
+}

--- a/npm/kitewright-mcp/npm/win32-x64-msvc/package.json
+++ b/npm/kitewright-mcp/npm/win32-x64-msvc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@kitewright/mcp-win32-x64-msvc",
+  "version": "0.1.0",
+  "description": "Prebuilt kite binary for kitewright-mcp on Windows x64.",
+  "license": "MIT",
+  "repository": "github:kitewright/kitewright",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": ["kite.exe"]
+}

--- a/npm/kitewright-mcp/package.json
+++ b/npm/kitewright-mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "kitewright-mcp",
+  "version": "0.1.0",
+  "description": "Kitewright browser-automation MCP server — run with npx, no build step. Backed by the Rust kite engine.",
+  "license": "MIT",
+  "repository": "github:kitewright/kitewright",
+  "bin": {
+    "kitewright-mcp": "bin.js"
+  },
+  "files": [
+    "bin.js"
+  ],
+  "optionalDependencies": {
+    "@kitewright/mcp-darwin-arm64": "0.1.0",
+    "@kitewright/mcp-darwin-x64": "0.1.0",
+    "@kitewright/mcp-linux-x64-gnu": "0.1.0",
+    "@kitewright/mcp-win32-x64-msvc": "0.1.0"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "browser",
+    "automation",
+    "playwright-alternative",
+    "kitewright"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
`npx kitewright-mcp` runs the kite MCP server with no build. Launcher resolves the prebuilt binary from an optional per-platform dep (esbuild pattern) and execs `kite --stdio`. Verified locally on darwin-arm64 (stdio handshake, 24 tools). Includes 4 platform manifests + a cross-build/publish workflow (needs npm token for first run).