### PR TITLE
Security hardening: secret-file fence + dep audit + exposure docs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,14 @@
+# cargo-audit policy (run: cargo audit). Vulnerabilities fail; unmaintained
+# advisories are warnings.
+[advisories]
+ignore = [
+  # quick-xml 0.38.4 DoS advisories (memory-exhaustion on namespace decls;
+  # quadratic on duplicate attribute names). Reached ONLY through
+  # typst -> hayagriva -> citationberg (bibliography CSL XML parsing), pulled by
+  # the `kite-pdf` workspace crate. The shipped `kite` MCP server does NOT depend
+  # on kite-pdf/typst (browser_pdf uses Chrome CDP Page.printToPDF), so these are
+  # not in the server's attack surface. citationberg pins ^0.38.1; awaiting an
+  # upstream typst/citationberg bump. RE-AUDIT if kite-pdf ever ships in a binary.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,9 @@ jobs:
             --skip-dirs target \
             --skip-dirs bindings/node/node_modules \
             .
+      - name: cargo audit (Rust dependency CVEs)
+        run: |
+          cargo install cargo-audit --locked || true
+          # Reads .cargo/audit.toml (documented ignores). Fails on any
+          # unignored vulnerability advisory.
+          cargo audit

--- a/README.md
+++ b/README.md
@@ -137,13 +137,37 @@ claude mcp add kite --transport http http://localhost:8090/mcp
 | `BROWSER_NO_SANDBOX` | unset | Set (any value) to pass `--no-sandbox` (containers) |
 | `KITE_HEADLESS` | unset | Kite launches a **headed** (visible) browser by default so you can watch automation. Set (any value) to run **headless** — required on servers, CI, and containers with no display, where a headed Chrome fails to launch |
 | `KITE_IDLE_TIMEOUT_SECS` | `1800` | Idle seconds before a headless browser is reaped to free memory. Default 30min keeps a session alive across normal pauses (headed never reaps). A reap that does happen is recovered by cookie **auto-restore**, so an authenticated session survives it. Lower it on a memory-constrained multi-session server |
-| `KITE_ALLOW_SECRET_FILES` | unset | Set (any value) to let `browser_fill_secret` read `file:/path` secrets from disk. Optionally fence reads to a directory with `KITE_SECRET_DIR`. `env:` secrets need no opt-in |
+| `KITE_ALLOW_SECRET_FILES` | unset | Set (any value) to let `browser_fill_secret` read `file:/path` secrets from disk. **Requires** `KITE_SECRET_DIR` (the directory reads are fenced to) so arbitrary host files can't be read/exfiltrated. `env:` secrets need no opt-in |
 | `KITE_VIEWPORT` | `1440x900` | Default viewport / window size as `WIDTHxHEIGHT` (Chromium's own default is a cramped 800x600). Adjust at runtime with the `browser_resize` tool |
 | `MCP_CONTEXT_POOL` | `2` | Number of pre-warmed blank browser contexts kept ready so a **new** session gets an instantly-usable context+page (zero context-creation latency). `0` disables. The pool refills in the background and drains with the browser on idle-reap (it never keeps the process alive) |
 | `KITE_CACHE_DIR` | `<tmp>/kitewright-cache` | Shared on-disk HTTP cache (`--disk-cache-dir`), stable across launches so repeat asset fetches hit cache. NOTE: per-session isolated contexts (cookie isolation) use an ephemeral cache; this benefits the browser's default context |
 | `KITE_PREWARM_URL` | unset | If set, prewarm navigates a throwaway page to this origin to establish DNS+TLS+connection before the first real navigate. No-op when unset |
 | `BROWSER_PREWARM` | unset | Set (any value) to launch + pre-warm the browser at server boot (otherwise prewarm fires when an MCP session initializes) |
 | `RUST_LOG` | `info` | Log filter |
+
+## Security
+
+Kitewright drives a real browser, so treat the endpoint as privileged. The
+defaults are safe for local use; harden before exposing it.
+
+- **Binds loopback (`127.0.0.1:8090`) by default.** It's only network-reachable
+  if you set `MCP_HTTP_BIND` explicitly. **If you expose it, set `MCP_AUTH_TOKEN`**
+  — without it the `/mcp` endpoint is unauthenticated (logged as a warning at
+  boot). Auth uses a constant-time compare; requests are rate-limited; and
+  cross-origin browser requests are rejected (DNS-rebinding protection).
+- **SSRF is inherent to a browser tool.** A caller can navigate to internal or
+  cloud-metadata addresses (`169.254.169.254`, RFC-1918, `localhost`) — which is
+  *the point* for local/dev automation, but a risk on an exposed instance.
+  Kitewright does not block these (doing so by default would break local
+  automation). On an exposed deployment, put it behind auth and network policy
+  that can't reach sensitive internal endpoints.
+- **Local-file access is off by default.** `file://` navigation requires
+  `KITE_ALLOW_FILE_URLS=1`; `browser_fill_secret` file reads require
+  `KITE_ALLOW_SECRET_FILES=1` **and** a `KITE_SECRET_DIR` fence (reads are
+  canonicalized and must stay under it).
+- **Dependencies** are scanned in CI (Trivy + `cargo audit`). The shipped `kite`
+  binary carries no known-vulnerable crates; see [`.cargo/audit.toml`](.cargo/audit.toml)
+  for two DoS advisories confined to the (server-unused) `kite-pdf` crate.
 
 ## Tools (v0.4)
 
@@ -169,7 +193,7 @@ All tools operate on the session's persistent page.
 - `browser_click {selector, timeout_ms?}` — scroll into view + click the first match
 - `browser_type {selector, text, clear?, press_enter?, timeout_ms?}` — focus and type into an element
 - `browser_fill_form {fields: [{selector, value}], timeout_ms?}` — fill several inputs in one call (per-field ok/error summary)
-- `browser_fill_secret {selector, secret_ref, press_enter?, timeout_ms?}` — type a secret (password) whose plaintext **never enters the tool call**: `secret_ref` is `env:NAME` (a server env var) or `file:/path` (opt-in via `KITE_ALLOW_SECRET_FILES`). Resolved server-side, then typed
+- `browser_fill_secret {selector, secret_ref, press_enter?, timeout_ms?}` — type a secret (password) whose plaintext **never enters the tool call**: `secret_ref` is `env:NAME` (a server env var) or `file:/path` (opt-in via `KITE_ALLOW_SECRET_FILES` + a required `KITE_SECRET_DIR` fence). Resolved server-side, then typed
 - `browser_select_option {selector, value?, label?, timeout_ms?}` — pick an `<option>` by value or visible label (fires `change`)
 - `browser_hover {selector, timeout_ms?}` — move the mouse to an element's center (reveals CSS `:hover` menus)
 - `browser_press_key {key}` — send Enter / Tab / Escape / ArrowDown / … to the focused element

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1275,7 +1275,7 @@ impl BrowserSession {
     /// Type a SECRET into `selector` without the plaintext ever appearing in the
     /// tool call. `secret_ref` is a reference resolved server-side:
     /// `env:NAME` (from the server's environment) or `file:/path` (from disk,
-    /// opt-in via `KITE_ALLOW_SECRET_FILES`, optionally fenced to
+    /// opt-in via `KITE_ALLOW_SECRET_FILES` and fenced to a required
     /// `KITE_SECRET_DIR`). Clears the field first, then types the resolved value.
     pub async fn fill_secret(
         &self,
@@ -1987,10 +1987,11 @@ fn resolve_actionable_timeout(timeout_ms: Option<u64>) -> Duration {
 /// Resolve a secret reference to its plaintext, server-side, so the value never
 /// travels in the MCP tool call. `env:NAME` reads `NAME` from the server's
 /// environment. `file:PATH` reads `PATH` from disk — opt-in via
-/// `KITE_ALLOW_SECRET_FILES=1`, and if `KITE_SECRET_DIR` is set the canonicalized
-/// path must live under it (mirroring the `KITE_ALLOW_FILE_URLS` anti-exfiltration
-/// guard); a trailing newline is trimmed. A bare value with no scheme is rejected
-/// — passing plaintext would defeat the purpose of the tool.
+/// `KITE_ALLOW_SECRET_FILES=1` AND fenced to a required `KITE_SECRET_DIR` (the
+/// canonicalized path must live under it, so arbitrary host files can't be read;
+/// mirrors the `KITE_ALLOW_FILE_URLS` anti-exfiltration guard); a trailing
+/// newline is trimmed. A bare value with no scheme is rejected — passing
+/// plaintext would defeat the purpose of the tool.
 fn resolve_secret_ref(reference: &str) -> Result<String> {
     if let Some(name) = reference.strip_prefix("env:") {
         std::env::var(name).map_err(|_| anyhow!("secret env var {name:?} is not set on the server"))
@@ -2001,16 +2002,23 @@ fn resolve_secret_ref(reference: &str) -> Result<String> {
                  reading secret values from local files"
             );
         }
+        // Require a directory fence: without it, an enabled file-secret could
+        // read ANY host file (/etc/passwd, ~/.ssh/id_rsa, …) and exfiltrate it
+        // by typing it into a field. KITE_SECRET_DIR bounds what's readable.
+        let dir = std::env::var("KITE_SECRET_DIR").map_err(|_| {
+            anyhow!(
+                "file: secrets require KITE_SECRET_DIR to be set (the directory secret files may \
+                 be read from) — this fences reads so arbitrary host files can't be exfiltrated"
+            )
+        })?;
+        let allowed = std::path::Path::new(&dir)
+            .canonicalize()
+            .context("KITE_SECRET_DIR does not exist")?;
         let canon = std::path::Path::new(path)
             .canonicalize()
             .map_err(|e| anyhow!("secret file {path:?}: {e}"))?;
-        if let Ok(dir) = std::env::var("KITE_SECRET_DIR") {
-            let allowed = std::path::Path::new(&dir)
-                .canonicalize()
-                .context("KITE_SECRET_DIR does not exist")?;
-            if !canon.starts_with(&allowed) {
-                bail!("secret file {path:?} is outside KITE_SECRET_DIR");
-            }
+        if !canon.starts_with(&allowed) {
+            bail!("secret file {path:?} is outside KITE_SECRET_DIR");
         }
         let content = std::fs::read_to_string(&canon)
             .map_err(|e| anyhow!("read secret file {path:?}: {e}"))?;

--- a/crates/engine/tests/engine_test.rs
+++ b/crates/engine/tests/engine_test.rs
@@ -747,13 +747,25 @@ async fn fill_secret_resolves_env_and_types_it() {
         .evaluate("document.getElementById('pw').value")
         .await
         .expect("evaluate failed");
-    assert_eq!(value, serde_json::json!("hunter2-secret"), "secret not typed");
+    assert_eq!(
+        value,
+        serde_json::json!("hunter2-secret"),
+        "secret not typed"
+    );
     // A schemeless (plaintext) reference is refused.
     assert!(
         s.fill_secret("#pw", "not-a-reference", false, None)
             .await
             .is_err(),
         "plaintext secret ref should be rejected"
+    );
+    // file: secrets are OFF by default (KITE_ALLOW_SECRET_FILES unset) — no
+    // arbitrary host-file reads without an explicit opt-in.
+    assert!(
+        s.fill_secret("#pw", "file:/etc/hostname", false, None)
+            .await
+            .is_err(),
+        "file: secret must be refused when KITE_ALLOW_SECRET_FILES is unset"
     );
     s.close().await;
     engine.shutdown().await;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -525,7 +525,7 @@ impl BrowserMcp {
     }
 
     #[tool(
-        description = "Type a SECRET (e.g. a password) into an input WITHOUT the plaintext appearing in the tool call/transcript. Pass `secret_ref` as `env:NAME` (a server environment variable) or `file:/path` (a local file, opt-in via KITE_ALLOW_SECRET_FILES). kitewright resolves it server-side and types it, clearing the field first."
+        description = "Type a SECRET (e.g. a password) into an input WITHOUT the plaintext appearing in the tool call/transcript. Pass `secret_ref` as `env:NAME` (a server environment variable) or `file:/path` (a local file, opt-in via KITE_ALLOW_SECRET_FILES + a required KITE_SECRET_DIR fence). kitewright resolves it server-side and types it, clearing the field first."
     )]
     async fn browser_fill_secret(
         &self,


### PR DESCRIPTION
Pre-launch security gate. Mandatory KITE_SECRET_DIR fence for file: secrets; cargo audit in CI with a documented ignore for 2 quick-xml DoS advisories (confined to the server-unused kite-pdf crate — server binary is clean); README Security section (loopback/auth/SSRF/file gating). Audit + build + clippy + fmt + blocking sim + engine tests green.